### PR TITLE
Bump prom/prometheus from v2.41.0 to v2.43.0 in /prometheus

### DIFF
--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,2 +1,2 @@
-FROM prom/prometheus:v2.41.0
+FROM prom/prometheus:v2.43.0
 LABEL org.opencontainers.image.source = "https://github.com/danopstech/containers"


### PR DESCRIPTION
Bumps prom/prometheus from v2.41.0 to v2.43.0.

---
updated-dependencies:
- dependency-name: prom/prometheus dependency-type: direct:production ...