### PR TITLE
Bump grafana/grafana from 9.3.2 to 9.4.7 in /grafana

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,2 +1,2 @@
-FROM grafana/grafana:9.3.2
+FROM grafana/grafana:9.4.7
 LABEL org.opencontainers.image.source = "https://github.com/danopstech/containers"


### PR DESCRIPTION
Bumps grafana/grafana from 9.3.2 to 9.4.7.

---
updated-dependencies:
- dependency-name: grafana/grafana dependency-type: direct:production update-type: version-update:semver-minor ...